### PR TITLE
Hack-y fix to 404 on gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
 - parcel build src/index.html --public-url ./
 before_deploy:
 - cp robots-nofollow.txt dist/robots.txt
+- ln -s dist/index.html dist/404.html
 deploy:
   github_token: "$GITHUB_TOKEN"
   keep_history: true


### PR DESCRIPTION
Trello card: 
https://trello.com/c/0qwW70t6/270-indexhtml-404

## Description

- Hack to stop 404. we will probably fix this in a different way next week.
-

@neontribe/sea-map
