### PR TITLE
269 improve test coverage

### DIFF
--- a/src/Page/Definition.elm
+++ b/src/Page/Definition.elm
@@ -1,4 +1,4 @@
-module Page.Definition exposing (Model, Msg, init, view)
+module Page.Definition exposing (Model, Msg, view)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)

--- a/src/Page/HelpSelfSingle.elm
+++ b/src/Page/HelpSelfSingle.elm
@@ -1,4 +1,4 @@
-module Page.HelpSelfSingle exposing (Model, Msg, init, view)
+module Page.HelpSelfSingle exposing (Model, Msg, view)
 
 import Copy.Keys exposing (..)
 import Copy.Text exposing (t)

--- a/src/Page/NotAlone.elm
+++ b/src/Page/NotAlone.elm
@@ -1,4 +1,4 @@
-module Page.NotAlone exposing (Model, Msg, init, update, view)
+module Page.NotAlone exposing (Model, Msg(..), update, view)
 
 import Browser.Dom as Dom
 import Copy.Keys exposing (Key(..))

--- a/tests/HelpSelfGridTest.elm
+++ b/tests/HelpSelfGridTest.elm
@@ -15,32 +15,39 @@ import Test.Html.Selector exposing (attribute, tag, text)
 
 suite : Test
 suite =
-    describe "HelpSelf grid View"
-        [ test "HelpSelf grid view has title" <|
+    describe "HelpSelfGrid View"
+        [ test "HelpSelfGrid view has title" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.contains [ Html.text (t HelpSelfTitle) ]
-        , test "HelpSelf grid view has nav link to get-help" <|
+        , test "HelpSelfGrid view has nav link to get-help" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t GetHelpPageSlug)) ]
-                    |> Query.has [ text "Get Help" ]
-        , test "HelpSelf grid view has nav link to not-alone" <|
+                    |> Query.has [ text (t ToGetHelpFromHelpSelfLink) ]
+        , test "HelpSelfGid view has nav link to not-alone" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t NotAlonePageSlug)) ]
-                    |> Query.has [ text "Read about others" ]
-        , test "HelpSelf grid view has nav link to definition" <|
+                    |> Query.has [ text (t ToNotAloneFromHelpSelfLink) ]
+        , test "HelpSelfGrid view has nav link to definition" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t DefinitionPageSlug)) ]
-                    |> Query.has [ text "What is Economic Abuse" ]
+                    |> Query.has [ text (t ToDefinitionFromHelpSelfLink) ]
+        , test "HelpSelfGrid view has 8 links (5 categories, 3 navigation)" <|
+            \() ->
+                view
+                    |> Html.Styled.toUnstyled
+                    |> Query.fromHtml
+                    |> Query.findAll [ tag "a" ]
+                    |> Query.count (Expect.equal 8)
         ]

--- a/tests/HelpSelfGridTest.elm
+++ b/tests/HelpSelfGridTest.elm
@@ -1,4 +1,4 @@
-module HelpSelfTest exposing (suite)
+module HelpSelfGridTest exposing (suite)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
@@ -15,28 +15,28 @@ import Test.Html.Selector exposing (attribute, tag, text)
 
 suite : Test
 suite =
-    describe "HelpSelf View"
-        [ test "HelpSelf view has title" <|
+    describe "HelpSelf grid View"
+        [ test "HelpSelf grid view has title" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.contains [ Html.text (t HelpSelfTitle) ]
-        , test "HelpSelf view has nav link to get-help" <|
+        , test "HelpSelf grid view has nav link to get-help" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t GetHelpPageSlug)) ]
                     |> Query.has [ text "Get Help" ]
-        , test "HelpSelf view has nav link to not-alone" <|
+        , test "HelpSelf grid view has nav link to not-alone" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t NotAlonePageSlug)) ]
                     |> Query.has [ text "Read about others" ]
-        , test "HelpSelf view has nav link to definition" <|
+        , test "HelpSelf grid view has nav link to definition" <|
             \() ->
                 view
                     |> Html.Styled.toUnstyled

--- a/tests/HelpSelfSingleTest.elm
+++ b/tests/HelpSelfSingleTest.elm
@@ -1,0 +1,32 @@
+module HelpSelfSingleTest exposing (suite)
+
+import Copy.Keys exposing (Key(..))
+import Copy.Text exposing (t)
+import Expect exposing (Expectation)
+import Html
+import Html.Attributes
+import Html.Styled
+import Page.HelpSelfSingle exposing (view)
+import Test exposing (Test, describe, test)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (attribute, tag, text)
+
+
+suite : Test
+suite =
+    describe "HelpSelfSingle View"
+        [ test "HelpSelfSingle view has title" <|
+            \() ->
+                view (t HelpSelfCategory1Slug) {}
+                    |> Html.Styled.toUnstyled
+                    |> Query.fromHtml
+                    |> Query.contains [ Html.text (t HelpSelfCategory1Title) ]
+        , test "HelpSelfSingle view has nav link to get-help" <|
+            \() ->
+                view (t HelpSelfCategory1Slug) {}
+                    |> Html.Styled.toUnstyled
+                    |> Query.fromHtml
+                    |> Query.find [ tag "a", attribute (Html.Attributes.href ("../" ++ t HelpSelfGridPageSlug)) ]
+                    |> Query.has [ text (t ToHelpSelfFromSingleCategoryLink) ]
+        ]

--- a/tests/HelpSelfSingleTest.elm
+++ b/tests/HelpSelfSingleTest.elm
@@ -10,7 +10,7 @@ import Page.HelpSelfSingle exposing (view)
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (attribute, tag, text)
+import Test.Html.Selector exposing (attribute, containing, tag, text)
 
 
 suite : Test
@@ -29,4 +29,19 @@ suite =
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href ("../" ++ t HelpSelfGridPageSlug)) ]
                     |> Query.has [ text (t ToHelpSelfFromSingleCategoryLink) ]
+        , test "HelpSelfSingle view can have well formed resources" <|
+            \() ->
+                view (t HelpSelfCategory2Slug) {}
+                    |> Html.Styled.toUnstyled
+                    |> Query.fromHtml
+                    |> Query.findAll [ tag "div", containing [ text (t HelpSelfCategory2Resource1Title) ] ]
+                    -- This is the 3rd div which contains the 1st resource
+                    |> Query.index 2
+                    |> Query.has
+                        [ text (t HelpSelfCategory2Resource1Quote1)
+                        , text (t HelpSelfCategory2Resource1Quote2)
+                        , text (t HelpSelfCategory2Resource1Summary)
+                        , text (t HelpSelfCategory2Resource1Link)
+                        , attribute (Html.Attributes.href (t HelpSelfCategory2Resource1Href))
+                        ]
         ]

--- a/tests/NotAloneTest.elm
+++ b/tests/NotAloneTest.elm
@@ -6,11 +6,11 @@ import Expect exposing (Expectation)
 import Html
 import Html.Attributes
 import Html.Styled
-import Page.NotAlone exposing (view)
+import Page.NotAlone exposing (Msg(..), view)
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (attribute, tag, text)
+import Test.Html.Selector exposing (attribute, containing, tag, text)
 
 
 suite : Test
@@ -36,4 +36,12 @@ suite =
                     |> Query.fromHtml
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t DefinitionPageSlug)) ]
                     |> Query.has [ text (t ToDefinitionFromNotAloneLink) ]
+        , test "When I click the Emergency button, the NotAlone page scrolls to #emergency" <|
+            \() ->
+                view {}
+                    |> Html.Styled.toUnstyled
+                    |> Query.fromHtml
+                    |> Query.find [ tag "button", containing [ text (t EmergencyButton) ] ]
+                    |> Event.simulate Event.click
+                    |> Event.expect ScrollTo
         ]


### PR DESCRIPTION
Trello card: 
Partial timeboxed - https://trello.com/c/PCbcd3Ee/269-test-coverage-strategy

## Description

- Improve tests for all pages
- Remove expose of unused `init`

@neontribe/sea-map
