### PR TITLE
Hardcode the fact about link in definition

### DIFF
--- a/src/Page/Definition.elm
+++ b/src/Page/Definition.elm
@@ -54,7 +54,7 @@ view model =
             , p [ css [ introStyle ] ]
                 [ text (t DefinitionConcise)
                 , text " "
-                , a [ href (t StatsOnEconomicAbuseHref) ] [ text (t DefinitionMoreLink) ]
+                , a [ href (t HelpSelfGridPageSlug ++ "/" ++ t HelpSelfCategory5Slug) ] [ text (t DefinitionMoreLink) ]
                 ]
             ]
         , dl [ css [ categoryListStyle ] ]

--- a/tests/DefinitionTest.elm
+++ b/tests/DefinitionTest.elm
@@ -35,12 +35,21 @@ suite =
                         |> Query.fromHtml
                         |> Query.findAll [ tag "a" ]
                         |> Query.count (Expect.equal 3)
-            , test "Definition view has nav link to stats resource" <|
+            , test "Definition view has link to facts and stats resources page" <|
                 \() ->
                     view initModel
                         |> Html.Styled.toUnstyled
                         |> Query.fromHtml
-                        |> Query.find [ tag "a", attribute (Html.Attributes.href (t StatsOnEconomicAbuseHref)) ]
+                        |> Query.find
+                            [ tag "a"
+                            , attribute
+                                (Html.Attributes.href
+                                    (t HelpSelfGridPageSlug
+                                        ++ "/"
+                                        ++ t HelpSelfCategory5Slug
+                                    )
+                                )
+                            ]
                         |> Query.has [ text (t DefinitionMoreLink) ]
             , test "Definition view has nav link to get-help" <|
                 \() ->


### PR DESCRIPTION
Trello card: 
https://trello.com/c/bvVAQ6Z5/294-link-to-legal-stats-definition-should-be-through-our-single-category-page

- Seems fragile. Not sure will work on gh-pages. This might be the time to refactor the routing?

## Description

- Hardcode the link to internal resources

@neontribe/sea-map
