### PR TITLE
Use base path so we can ignore in elm routing

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -21,7 +21,11 @@ import View.HelpSelfSingle
 import View.NotAlone
 
 
-main : Program () Model Msg
+type alias Flags =
+    { basePath : String }
+
+
+main : Program Flags Model Msg
 main =
     Browser.application
         { init = init
@@ -38,14 +42,15 @@ main =
 
 
 type alias Model =
-    { key : Browser.Navigation.Key
+    { flags : Flags
+    , key : Browser.Navigation.Key
     , page : Page
     }
 
 
-init : () -> Url.Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
-init _ url key =
-    ( { key = key, page = pageFromMaybeRoute (Route.fromUrl url) }, Cmd.none )
+init : Flags -> Url.Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
+init flags url key =
+    ( { flags = flags, key = key, page = pageFromMaybeRoute (Route.fromUrl flags.basePath url) }, Cmd.none )
 
 
 type Page
@@ -110,7 +115,7 @@ update msg model =
         UrlChanged url ->
             let
                 newPage =
-                    pageFromMaybeRoute (Route.fromUrl url)
+                    pageFromMaybeRoute (Route.fromUrl model.flags.basePath url)
             in
             ( { model | page = newPage }, resetViewportTop )
 

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -19,9 +19,9 @@ type Route
     | NotAlone
 
 
-fromUrl : Url.Url -> Maybe Route
-fromUrl url =
-    { url | path = url.path }
+fromUrl : String -> Url.Url -> Maybe Route
+fromUrl basePath url =
+    { url | path = String.replace basePath "" url.path }
         |> Parser.parse routeParser
 
 

--- a/src/View/Definition.elm
+++ b/src/View/Definition.elm
@@ -9,6 +9,7 @@ import Html.Styled exposing (Html, a, blockquote, button, dd, div, dl, dt, h1, h
 import Html.Styled.Attributes exposing (css, href)
 import Html.Styled.Events exposing (onClick)
 import Page.Definition exposing (CategoryDefinition, DefinitionCategory(..), Model, Msg(..), categoryIsExpanded, categoryKeysFromListPosition)
+import Route exposing (Route(..), toString)
 import Theme exposing (grey, lightGrey, navLinkStyle, pageHeadingStyle, purple, verticalSpacing, white)
 
 
@@ -44,11 +45,11 @@ view model =
         , nav []
             [ ul [ css [ navListStyle ] ]
                 [ li [ css navItemStyles ]
-                    [ a [ href (t HelpSelfGridPageSlug), css [ navLinkStyle ] ]
+                    [ a [ href (Route.toString HelpSelfGrid), css [ navLinkStyle ] ]
                         [ span [] [ text (t ToHelpSelfFromDefinitionLink) ] ]
                     ]
                 , li [ css navItemStyles ]
-                    [ a [ href (t GetHelpPageSlug), css [ navLinkStyle ] ]
+                    [ a [ href (Route.toString GetHelp), css [ navLinkStyle ] ]
                         [ span [] [ text (t ToGetHelpFromDefinitionLink) ] ]
                     ]
                 ]

--- a/src/View/NotAlone.elm
+++ b/src/View/NotAlone.elm
@@ -9,7 +9,8 @@ import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, href, id)
 import Html.Styled.Events exposing (onClick)
 import Page.NotAlone exposing (JourneyCard(..), Model, Msg(..), journeyContentFromCardPosition, journeyIsRevealed)
-import Theme exposing (grey, globalStyles, gridStyle, lightGrey, navLinkStyle, oneColumn, pageHeadingStyle, purple, twoColumn, verticalSpacing, white)
+import Route exposing (Route(..), toString)
+import Theme exposing (globalStyles, grey, gridStyle, lightGrey, navLinkStyle, oneColumn, pageHeadingStyle, purple, twoColumn, verticalSpacing, white)
 
 
 view : Model -> Html Msg
@@ -73,7 +74,7 @@ renderInitCard journeyCardPosition =
         [ p []
             [ text (t ToDefinitionReassuringText) ]
         , a
-            [ href (t DefinitionPageSlug) ]
+            [ href (Route.toString Definition) ]
             [ span [] [ text (t ToDefinitionFromNotAloneLink) ] ]
         ]
     ]

--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <title>Economic Abuse Support Tool</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="styles/reset.css">
-    <link rel="stylesheet" href="styles/fonts.css">
+    <!-- elm routing will ignore this string in the path -->
+    <base href="/sea-map" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="styles/reset.css" />
+    <link rel="stylesheet" href="styles/fonts.css" />
   </head>
 
   <body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,8 @@
 import { Elm } from "../Main.elm";
 
+const basePath = new URL(document.baseURI).pathname;
+
 Elm.Main.init({
-  node: document.getElementById("app")
+  node: document.getElementById("app"),
+  flags: { basePath },
 });


### PR DESCRIPTION
Trello card: https://trello.com/c/efAoIZuo/400-vvv-ee-implement-base-url-for-absolute-paths

## Description

- Strip out sea-map in the elm routing if it exists.
- might be able to greatly simplify.

@neontribe/sea-map
