### PR TITLE
styling for grid cards

### DIFF
--- a/src/Theme.elm
+++ b/src/Theme.elm
@@ -1,4 +1,4 @@
-module Theme exposing (container, containerContent, globalStyles, green, grey, gridStyle, lightGreen, lightGrey, lightOrange, lightPink, lightPurple, lightTeal, navItemStyles, navLinkStyle, navListStyle, oneColumn, orange, pageHeadingStyle, pink, purple, teal, threeColumn, twoColumn, verticalSpacing, white)
+module Theme exposing (container, containerContent, globalStyles, green, grey, gridStyle, lightGreen, lightGrey, lightOrange, lightPink, lightPurple, lightTeal, navItemStyles, navLinkStyle, navListStyle, oneColumn, orange, pageHeadingStyle, pink, pureWhite, purple, shadowGrey, teal, threeColumn, twoColumn, verticalSpacing, white)
 
 import Css exposing (..)
 import Css.Global exposing (adjacentSiblings, global, typeSelector)
@@ -83,9 +83,19 @@ lightGrey =
     hex "ededed"
 
 
+shadowGrey : Color
+shadowGrey =
+    rgba 74 77 80 0.3
+
+
 white : Color
 white =
     hex "fafafa"
+
+
+pureWhite : Color
+pureWhite =
+    hex "ffffff"
 
 
 {-| Injects a <style> tag into the body, and can target element or

--- a/src/View/HelpSelfGrid.elm
+++ b/src/View/HelpSelfGrid.elm
@@ -6,7 +6,7 @@ import Css exposing (..)
 import Css.Media as Media exposing (minWidth, only, screen, withMedia)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, href)
-import Theme exposing (globalStyles, grey, gridStyle, lightGrey, navItemStyles, navLinkStyle, navListStyle, pageHeadingStyle, purple, threeColumn, twoColumn, verticalSpacing)
+import Theme exposing (globalStyles, green, gridStyle, lightGrey, navItemStyles, navLinkStyle, navListStyle, pageHeadingStyle, pureWhite, purple, shadowGrey, threeColumn, twoColumn, verticalSpacing, white)
 
 
 view : Html never
@@ -61,9 +61,9 @@ infoLink linkName linkHref =
 gridCardStyle : Style
 gridCardStyle =
     batch
-        [ backgroundColor lightGrey
-        , border3 (px 1) solid grey
-        , borderRadius (rem 1)
+        [ backgroundColor pureWhite
+        , borderRadius (rem 1.8)
+        , boxShadow5 (px 0) (px 3) (px 5) (px 0) shadowGrey
         , color purple
         , displayFlex
         , flexDirection column
@@ -71,10 +71,15 @@ gridCardStyle =
         , fontSize (rem 1.25)
         , justifyContent center
         , minHeight (px 150)
+        , padding2 zero (rem 1)
         , textAlign center
         , textDecoration none
         , hover
-            [ borderColor purple
+            [ border3 (px 3) solid green
+            ]
+        , focus
+            [ border3 (px 3) solid green
+            , outline zero
             ]
         ]
 


### PR DESCRIPTION
Trello card: https://trello.com/c/YYXO3JDd/377-vv-ee-alter-design-of-the-navigation-controls-make-consistent-between-pages

## Description

- Grid page card styling
- I've tried to colour match the shadow from the design using an opacity (rgba) of our text grey

![image](https://user-images.githubusercontent.com/32434620/91204665-4f9c1e80-e6fc-11ea-8f2f-012391b7063a.png)

@neontribe/sea-map
