### PR TITLE
389 exit button

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -67,6 +67,7 @@ type Key
     | ExpandQuoteButton
     | ToDefinitionReassuringText
     | ToDefinitionFromNotAloneLink
+    | ExitButton
     | EmergencyButton
     | EmergencyReassure
     | EmergencyPoliceInfo

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -200,6 +200,9 @@ t key =
         ToDefinitionFromNotAloneLink ->
             "Find out about economic abuse"
 
+        ExitButton ->
+            "EXIT SITE"
+
         EmergencyButton ->
             "I need help"
 

--- a/src/PageTemplate.elm
+++ b/src/PageTemplate.elm
@@ -14,6 +14,7 @@ page : List (Html msg) -> Html msg
 page children =
     div [ css [ minHeight (vh 100), waveStyle ] ]
         ([ globalStyles
+         , a [ href "https://www.google.co.uk/", css [ exitButtonStyle ] ] [ text (t ExitButton) ]
          , button [ css [ emergencyButtonStyle ] ]
             [ span [] [ text (t EmergencyButton) ]
             , img [ css [ iconStyle ], src "Emergency.svg", alt "" ] []
@@ -108,6 +109,26 @@ waveStyle =
         ]
 
 
+exitButtonStyle : Style
+exitButtonStyle =
+    batch
+        [ backgroundColor orange
+        , border zero
+        , color white
+        , fontSize (rem 1.2)
+        , fontWeight (int 400)
+        , height (rem 3.75)
+        , lineHeight (num 1.2)
+        , padding (px 6)
+        , position fixed
+        , right zero
+        , textAlign center
+        , textDecoration none
+        , top (rem 5)
+        , width (rem 3.75)
+        ]
+
+
 emergencyPanelStyle : Style
 emergencyPanelStyle =
     batch
@@ -170,9 +191,6 @@ emergencyPanelBodyStyle =
         , borderBottomLeftRadius (px 20)
         , borderBottomRightRadius (px 20)
         , padding (rem 1.5)
-        , withMedia [ only screen [ Media.minWidth (px 576) ] ]
-            [ borderRadius zero
-            ]
         ]
 
 

--- a/tests/DefinitionTest.elm
+++ b/tests/DefinitionTest.elm
@@ -37,11 +37,11 @@ suite =
                 \() ->
                     queryFromStyledHtml pageViewInitModel
                         |> Query.contains [ Html.text (t DefinitionTitle) ]
-            , test "Definition view has 5 nav links (2 navigation, 3 emergency)" <|
+            , test "Definition view has 6 nav links (2 navigation, 3 emergency, 1 exit)" <|
                 \() ->
                     queryFromStyledHtml pageViewInitModel
                         |> Query.findAll [ tag "a" ]
-                        |> Query.count (Expect.equal 5)
+                        |> Query.count (Expect.equal 6)
             , test "Definition view has nav link to get-help" <|
                 \() ->
                     queryFromStyledHtml pageViewInitModel

--- a/tests/HelpSelfGridTest.elm
+++ b/tests/HelpSelfGridTest.elm
@@ -36,9 +36,9 @@ suite =
                 queryFromStyledHtml (page view)
                     |> Query.find [ tag "a", attribute (Html.Attributes.href (t DefinitionPageSlug)) ]
                     |> Query.has [ text (t ToDefinitionFromHelpSelfLink) ]
-        , test "HelpSelfGrid view has 13 links (7 categories, 3 navigation, 3 emergency)" <|
+        , test "HelpSelfGrid view has 14 links (7 categories, 3 navigation, 3 emergency, 1 exit)" <|
             \() ->
                 queryFromStyledHtml (page view)
                     |> Query.findAll [ tag "a" ]
-                    |> Query.count (Expect.equal 13)
+                    |> Query.count (Expect.equal 14)
         ]

--- a/tests/NotAloneTest.elm
+++ b/tests/NotAloneTest.elm
@@ -28,11 +28,11 @@ suite =
             \() ->
                 queryFromStyledHtml pageViewInitModel
                     |> Query.contains [ Html.text (t NotAloneTitle) ]
-        , test "NotAlone view has 5 nav links (1 navigation, 3 emergency)" <|
+        , test "NotAlone view has 5 nav links (1 navigation, 3 emergency, 1 exit)" <|
             \() ->
                 queryFromStyledHtml pageViewInitModel
                     |> Query.findAll [ tag "a" ]
-                    |> Query.count (Expect.equal 4)
+                    |> Query.count (Expect.equal 5)
         , test "NotAlone view has nav links to definition" <|
             \() ->
                 queryFromStyledHtml pageViewInitModel


### PR DESCRIPTION
Trello card: https://trello.com/c/H1RjmHU2/389-v-ee-add-a-persistent-quick-exit-button-to-the-side-of-all-pages

## Description

- Button!

@neontribe/sea-map
