### PR TITLE
229 google and cookies

### DIFF
--- a/src/Analytics.elm
+++ b/src/Analytics.elm
@@ -1,0 +1,29 @@
+port module Analytics exposing (updateAnalytics, updateAnalyticsEvent, updateAnalyticsPage)
+
+-- js ports can only take one arg - so bundle event strings
+
+
+type alias GaEvent =
+    { category : String
+    , action : String
+    , label : String
+    }
+
+
+
+-- We only want to send analytics info if we have cookie consent
+
+
+updateAnalytics : Bool -> Cmd msg -> Cmd msg
+updateAnalytics hasConsented sendAnalyticsMessage =
+    if hasConsented then
+        sendAnalyticsMessage
+
+    else
+        Cmd.none
+
+
+port updateAnalyticsPage : String -> Cmd msg
+
+
+port updateAnalyticsEvent : GaEvent -> Cmd msg

--- a/src/CookieContent.elm
+++ b/src/CookieContent.elm
@@ -12,6 +12,7 @@ import Theme exposing (..)
 type alias CookieState =
     { cookieBannerIsOpen : Bool
     , privacyInfoIsOpen : Bool
+    , hasConsentedToCookies : Bool
     }
 
 

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -114,7 +114,7 @@ t key =
 
         -- Cookies and Privacy
         CookieBannerP ->
-            "[cCc] Cookie banner intro text"
+            "[cCc] Can we use cookies to help improve this site? We'd like to use Google Analytics cookies to collect and report information on how people use the site. Allowing us to use cookies does not allow us to identify you."
 
         CookieBannerPrivacyButton ->
             "[cCc] Privacy information"

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -1,4 +1,4 @@
-port module Message exposing (CookieButton(..), Msg(..), gaEvent, updateAnalyticsEvent, updateAnalyticsPage)
+module Message exposing (CookieButton(..), Msg(..))
 
 import Browser
 import Browser.Dom
@@ -33,28 +33,3 @@ type CookieButton
     | ViewPrivacy
     | AcceptCookies
     | DeclineCookies
-
-
-
--- js ports can only take one arg - so bundle event strings
-
-
-type alias GaEvent =
-    { category : String
-    , action : String
-    , label : String
-    }
-
-
-gaEvent : String -> String -> String -> GaEvent
-gaEvent category action label =
-    { category = category
-    , action = action
-    , label = label
-    }
-
-
-port updateAnalyticsPage : String -> Cmd msg
-
-
-port updateAnalyticsEvent : GaEvent -> Cmd msg

--- a/src/View/NotAlone.elm
+++ b/src/View/NotAlone.elm
@@ -12,8 +12,8 @@ import Route exposing (Direction(..), Route(..), renderNavLink)
 import Theme exposing (container, containerContent, green, grey, lightGreen, lightPurple, navListStyle, oneColumn, pageHeadingStyle, pureWhite, purple, shadowGrey, threeColumn, twoColumn, verticalSpacing, white, withMediaDesktop, withMediaTabletOrDesktop)
 
 
-view : Model -> Html Msg
-view model =
+view : Bool -> Model -> Html Msg
+view hasConsented model =
     div []
         [ containerContent
             [ header []
@@ -22,12 +22,12 @@ view model =
             ]
         , container
             [ ul [ css [ gridStyle ] ]
-                [ card model JourneyCard1
-                , card model JourneyCard2
-                , card model JourneyCard3
-                , card model JourneyCard4
-                , card model JourneyCard5
-                , card model JourneyCard6
+                [ card hasConsented model JourneyCard1
+                , card hasConsented model JourneyCard2
+                , card hasConsented model JourneyCard3
+                , card hasConsented model JourneyCard4
+                , card hasConsented model JourneyCard5
+                , card hasConsented model JourneyCard6
                 ]
             ]
         , verticalSpacing 2
@@ -40,22 +40,22 @@ view model =
         ]
 
 
-card : Model -> JourneyCard -> Html Msg
-card model journeyCardPosition =
-    renderCard model journeyCardPosition
+card : Bool -> Model -> JourneyCard -> Html Msg
+card hasConsented model journeyCardPosition =
+    renderCard hasConsented model journeyCardPosition
 
 
-renderCard : Model -> JourneyCard -> Html Msg
-renderCard model journeyCardPosition =
+renderCard : Bool -> Model -> JourneyCard -> Html Msg
+renderCard hasConsented model journeyCardPosition =
     if journeyIsRevealed model journeyCardPosition then
-        renderRevealedCard journeyCardPosition
+        renderRevealedCard hasConsented journeyCardPosition
 
     else
-        renderInitCard journeyCardPosition
+        renderInitCard hasConsented journeyCardPosition
 
 
-renderInitCard : JourneyCard -> Html Msg
-renderInitCard journeyCardPosition =
+renderInitCard : Bool -> JourneyCard -> Html Msg
+renderInitCard hasConsented journeyCardPosition =
     let
         journeyContent =
             journeyContentFromCardPosition journeyCardPosition
@@ -64,7 +64,7 @@ renderInitCard journeyCardPosition =
         [ div [ css [ innerCardStyle ] ]
             [ h2 [ css [ teaserStyle ] ] [ text (t journeyContent.teaser) ]
             , div [ css [ greenDividerStyle ] ] []
-            , button [ css [ buttonStyle ], onClick (ToggleJourney journeyCardPosition) ]
+            , button [ css [ buttonStyle ], onClick (ToggleJourney hasConsented journeyCardPosition) ]
                 [ span [ css [ whiteSpace noWrap ] ] [ text (t ExpandQuoteButton) ]
                 , img [ src "/Arrow.svg", alt "", css [ forwardArrowStyle ] ] []
                 ]
@@ -72,15 +72,15 @@ renderInitCard journeyCardPosition =
         ]
 
 
-renderRevealedCard : JourneyCard -> Html Msg
-renderRevealedCard journeyCardPosition =
+renderRevealedCard : Bool -> JourneyCard -> Html Msg
+renderRevealedCard hasConsented journeyCardPosition =
     let
         journeyContent =
             journeyContentFromCardPosition journeyCardPosition
     in
     li [ css [ cardStyle, openStyle ] ]
         [ div []
-            [ button [ css [ closeJourneyButtonStyle ], onClick (ToggleJourney journeyCardPosition) ]
+            [ button [ css [ closeJourneyButtonStyle ], onClick (ToggleJourney hasConsented journeyCardPosition) ]
                 [ img [ css [ height (px 44), margin auto ], src "/Close.svg", alt "Close" ] []
                 ]
             , p [ css [ quoteStyle ] ] [ text (t journeyContent.relatable) ]

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" href="styles/reset.css" />
     <link rel="stylesheet" href="https://use.typekit.net/pry3rja.css" />
     <link rel="stylesheet" href="styles/fonts.css" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-30970110-8"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-30970110-8');
+    </script>
   </head>
 
   <body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,17 @@
 import { Elm } from "../Main.elm";
 
-Elm.Main.init({
+var elm = Elm.Main.init({
   node: document.getElementById("app")
 });
+
+
+
+// Google analytics subscribe to page changes and custom events
+elm.ports.updateAnalyticsPage.subscribe(function (page) {
+    gtag('config', 'UA-30970110-8', { 'page_path': page });
+});
+
+elm.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
+    gtag('event', gaEvent.action, { 'event_category' : gaEvent.category, 'event_label' : gaEvent.label });
+});
+

--- a/tests/NotAloneTest.elm
+++ b/tests/NotAloneTest.elm
@@ -21,22 +21,22 @@ suite =
         initModel =
             { revealedJourney = Nothing }
 
-        viewInitModel =
-            view initModel
+        viewInitModelWithoutCookieConsent =
+            view False initModel
     in
     describe "NotAlone View"
         [ test "NotAlone view has title" <|
             \() ->
-                queryFromStyledHtml viewInitModel
+                queryFromStyledHtml viewInitModelWithoutCookieConsent
                     |> Query.contains [ Html.text (t NotAloneTitle) ]
         , test "NotAlone view has 1 nav link" <|
             \() ->
-                queryFromStyledHtml viewInitModel
+                queryFromStyledHtml viewInitModelWithoutCookieConsent
                     |> Query.findAll [ tag "a" ]
                     |> Query.count (Expect.equal 1)
         , test "NotAlone view has nav links to definition" <|
             \() ->
-                queryFromStyledHtml viewInitModel
+                queryFromStyledHtml viewInitModelWithoutCookieConsent
                     |> Query.findAll [ tag "a", attribute (Html.Attributes.href (t DefinitionPageSlug)) ]
                     |> Query.each (Query.has [ text (t ToDefinitionFromNotAloneLink) ])
 


### PR DESCRIPTION
Trello card: 
https://trello.com/c/K6GY0FNG/229-vvv-eee-add-google-analytics-with-cookie-banner

## Description

- GA tracks page views - if consent for cookies given
- GA Tracks open and close events on survivor stories - if consent for cookies given

@neontribe/sea-map
