### PR TITLE
471 copy and design tweak

### DIFF
--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -157,7 +157,7 @@ t key =
             "He considered my money\u{00A0}his"
 
         Journey1Image ->
-            "/Person_2.svg"
+            "/Person_1.svg"
 
         Journey1Relatable ->
             "Over the years, the [criticism, blame and undermining] increased. He used to run me down, tell me I was stupid at dinner parties... He considered my money his, and when I bought something with [my money] he got very cross. He would stand over me or block the door, and once tried to push me down the stairs."
@@ -173,7 +173,7 @@ t key =
             "He threw my phone on the floor and smashed\u{00A0}it"
 
         Journey2Image ->
-            "/Person_1.svg"
+            "/Person_2.svg"
 
         Journey2Relatable ->
             "When I took a call from someone my boyfriend didn't approve of, he threw my [mobile phone] on the floor and smashed it. I had to buy 3 new phones last year."
@@ -257,7 +257,7 @@ t key =
             "Close button"
 
         ExitButton ->
-            "EXIT SITE"
+            "QUICK EXIT"
 
         EmergencyButton ->
             "I need help"

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -215,13 +215,13 @@ t key =
             "It's really made me think. I can see the connection between the abuser's behaviour and my financial situation now."
 
         Journey5Teaser ->
-            "He took out loans in my\u{00A0}name"
+            "There were loans in my name that I knew nothing\u{00A0}about"
 
         Journey5Image ->
             "/Person_5.svg"
 
         Journey5Relatable ->
-            "When I left the relationship I realised he had taken out [loans and credit cards] in joint names I knew nothing about."
+            "When I left the relationship I realised my ex had taken out loans and credit cards in joint names I knew nothing about."
 
         Journey5Hopeful ->
             "I had been putting off speaking to anyone as I didn't know how to approach these companies. But with the help of my debt advisor, I was successful in removing a contract in my name and the debt was written off in full."

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -84,6 +84,8 @@ exitButtonStyle =
         [ backgroundColor orange.colour
         , border zero
         , color white
+        , displayFlex
+        , alignItems center
         , fontSize (rem 1.1)
         , fontWeight (int 400)
         , height (rem 3.75)

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -223,9 +223,9 @@ iconStyle =
 linkStyle : Style
 linkStyle =
     batch
-        [ color purple
+        [ color orange.colour
         , hover
-            [ color grey ]
+            [ color lightOrange ]
         , focus
             [ border3 (px 3) solid teal.colour
             , outline zero

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -223,7 +223,7 @@ iconStyle =
 linkStyle : Style
 linkStyle =
     batch
-        [ color orange.colour
+        [ color purple
         , hover
             [ color darkOrange ]
         , focus

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -159,7 +159,7 @@ emergencyPanelHeaderButtonStyle =
             [ border3 (px 3) solid lightPurple
             ]
         , focus
-            [ border3 (px 3) solid teal
+            [ border3 (px 3) solid teal.colour
             , outline none
             ]
         ]

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -225,7 +225,7 @@ linkStyle =
     batch
         [ color orange.colour
         , hover
-            [ color lightOrange ]
+            [ color darkOrange ]
         , focus
             [ border3 (px 3) solid teal.colour
             , outline zero

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -3,7 +3,7 @@ module EmergencyContent exposing (renderEmergencyButton, renderEmergencyPanel, r
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Css exposing (..)
-import Html.Styled exposing (Html, a, button, div, img, li, p, span, text, ul)
+import Html.Styled exposing (Html, a, b, button, div, img, li, p, span, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, id, src)
 import Html.Styled.Events exposing (onClick)
 import Message exposing (Msg(..))
@@ -30,11 +30,12 @@ renderEmergencyPanel viewportWidth =
                 [ text (t EmergencyPoliceInfo)
                 , text " "
                 , renderPhoneNumber viewportWidth (t EmergencyPoliceNumber)
+                , text "."
                 ]
             , p [] [ text (t EmergencyNotImmediateReassure) ]
             , ul [ css [ listStyle none, margin2 (rem 1) zero ] ]
                 [ li [ css [ marginBottom (rem 1) ] ]
-                    [ a [ href (t DomesticAbuseHref) ]
+                    [ a [ css [ linkStyle ], href (t DomesticAbuseHref) ]
                         [ text
                             (t EmergencyDomesticAbuseLink)
                         ]
@@ -46,7 +47,7 @@ renderEmergencyPanel viewportWidth =
                     , text (t EmergencyDomesticAbuseInfo)
                     ]
                 , li [ css [ marginBottom (rem 1) ] ]
-                    [ a [ href (t WomensAidHref) ]
+                    [ a [ css [ linkStyle ], href (t WomensAidHref) ]
                         [ text
                             (t EmergencyWomensAidLink)
                         ]
@@ -54,7 +55,7 @@ renderEmergencyPanel viewportWidth =
                     , text (t EmergencyWomensAidInfo)
                     ]
                 ]
-            , p [] [ a [ href (t SeaOrganisationsResourceHref) ] [ text (t EmergencyOtherOrganisationsLink) ] ]
+            , p [] [ a [ css [ linkStyle ], href (t SeaOrganisationsResourceHref) ] [ text (t EmergencyOtherOrganisationsLink) ] ]
             ]
         ]
 
@@ -62,10 +63,10 @@ renderEmergencyPanel viewportWidth =
 renderPhoneNumber : Float -> String -> Html msg
 renderPhoneNumber viewportWidth phonenumber =
     if viewportWidth <= Theme.maxMobile then
-        a [ href ("tel:" ++ String.replace " " "" phonenumber) ] [ text phonenumber ]
+        a [ css [ linkStyle ], href ("tel:" ++ String.replace " " "" phonenumber) ] [ text phonenumber ]
 
     else
-        text phonenumber
+        b [] [ text phonenumber ]
 
 
 renderEmergencyButton : Html Msg
@@ -83,17 +84,17 @@ exitButtonStyle =
         [ backgroundColor orange.colour
         , border zero
         , color white
-        , fontSize (rem 1.2)
+        , fontSize (rem 1.1)
         , fontWeight (int 400)
         , height (rem 3.75)
         , lineHeight (num 1.2)
-        , padding (px 6)
+        , padding (px 5)
         , position fixed
         , right zero
         , textAlign center
         , textDecoration none
         , top (rem 5)
-        , width (rem 3.75)
+        , width (rem 3.9)
         , zIndex (int 2)
         ]
 
@@ -216,4 +217,17 @@ iconStyle =
     batch
         [ height (px 50)
         , marginTop (px 10)
+        ]
+
+
+linkStyle : Style
+linkStyle =
+    batch
+        [ color purple
+        , hover
+            [ color grey ]
+        , focus
+            [ border3 (px 3) solid teal.colour
+            , outline zero
+            ]
         ]

--- a/src/EmergencyContent.elm
+++ b/src/EmergencyContent.elm
@@ -229,7 +229,6 @@ linkStyle =
         , hover
             [ color darkOrange ]
         , focus
-            [ border3 (px 3) solid teal.colour
-            , outline zero
+            [ outline3 (px 3) solid teal.colour
             ]
         ]

--- a/src/Page/NotAlone.elm
+++ b/src/Page/NotAlone.elm
@@ -5,7 +5,7 @@ import Browser.Dom as Dom
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Task
-import Theme exposing (green, orange, pink)
+import Theme exposing (green, orange, pink, teal)
 
 
 type alias Model =
@@ -132,7 +132,7 @@ journeyContentFromCardPosition cardPosition =
             , relatable = Journey5Relatable
             , hopeful = Journey5Hopeful
             , statement = Journey5Statement
-            , color = orange.string
+            , color = teal.string
             }
 
         JourneyCard6 ->

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -110,7 +110,7 @@ navLinkStyle =
             , color grey
             ]
         , focus
-            [ border3 (px 3) solid teal
+            [ border3 (px 3) solid teal.colour
             , outline zero
             ]
         , transition

--- a/src/Theme.elm
+++ b/src/Theme.elm
@@ -1,4 +1,4 @@
-module Theme exposing (container, containerContent, expanderButtonStyle, expanderClosedStyle, expanderDefinitionStyles, expanderHeadingStyle, expanderItemStyle, expanderOpenStyle, expanderSymbolStyle, generateId, globalStyles, green, grey, gridStyle, lightGreen, lightGrey, lightOrange, lightPink, lightPurple, lightTeal, maxMobile, navItemStyles, navListStyle, oneColumn, orange, pageHeadingStyle, pink, pureWhite, purple, quoteStyle, renderWithKeywords, rotate90Style, shadowGrey, teal, threeColumn, twoColumn, verticalSpacing, waveStyle, white, withMediaDesktop, withMediaTabletOrDesktop)
+module Theme exposing (container, containerContent, darkOrange, expanderButtonStyle, expanderClosedStyle, expanderDefinitionStyles, expanderHeadingStyle, expanderItemStyle, expanderOpenStyle, expanderSymbolStyle, generateId, globalStyles, green, grey, gridStyle, lightGreen, lightGrey, lightOrange, lightPink, lightPurple, lightTeal, maxMobile, navItemStyles, navListStyle, oneColumn, orange, pageHeadingStyle, pink, pureWhite, purple, quoteStyle, renderWithKeywords, rotate90Style, shadowGrey, teal, threeColumn, twoColumn, verticalSpacing, waveStyle, white, withMediaDesktop, withMediaTabletOrDesktop)
 
 import Css exposing (..)
 import Css.Global exposing (adjacentSiblings, global, typeSelector)
@@ -36,6 +36,11 @@ orange =
 lightOrange : Color
 lightOrange =
     hex "ffece8"
+
+
+darkOrange : Color
+darkOrange =
+    hex "ac3c2d"
 
 
 

--- a/src/Theme.elm
+++ b/src/Theme.elm
@@ -164,6 +164,9 @@ globalStyles =
             [ color purple
             , fontFamilies [ "Raleway", "sansSerif" ]
             ]
+        , typeSelector "b"
+            [ fontWeight (int 700)
+            ]
         , typeSelector "p"
             [ adjacentSiblings
                 [ typeSelector "p"

--- a/src/Theme.elm
+++ b/src/Theme.elm
@@ -66,9 +66,11 @@ lightPink =
     hex "ffddee"
 
 
-teal : Color
+teal : { colour : Color, string : String }
 teal =
-    hex "67c4ba"
+    { colour = hex "67c4ba"
+    , string = "#67c4ba"
+    }
 
 
 lightTeal : Color
@@ -277,7 +279,7 @@ expanderButtonStyle =
         , textAlign left
         , width (pct 100)
         , focus
-            [ border3 (px 3) solid teal
+            [ border3 (px 3) solid teal.colour
             , outline zero
             ]
         ]
@@ -360,7 +362,7 @@ quoteStyle =
             [ borderLeft3 (px 2) solid orange.colour
             ]
         , nthOfType "2n"
-            [ borderLeft3 (px 2) solid teal
+            [ borderLeft3 (px 2) solid teal.colour
             ]
         , nthOfType "3n"
             [ borderLeft3 (px 2) solid pink.colour

--- a/src/View/Definition.elm
+++ b/src/View/Definition.elm
@@ -43,10 +43,10 @@ view hasConsented model =
             , nav []
                 [ ul [ css [ navListStyle ] ]
                     [ li [ css navItemStyles ]
-                        [ renderNavLink Forward HelpSelfGrid ToHelpSelfFromDefinitionLink
+                        [ renderNavLink None HelpSelfGrid ToHelpSelfFromDefinitionLink
                         ]
                     , li [ css navItemStyles ]
-                        [ renderNavLink Forward GetHelp ToGetHelpFromDefinitionLink
+                        [ renderNavLink None GetHelp ToGetHelpFromDefinitionLink
                         ]
                     ]
                 ]

--- a/src/View/GetHelp.elm
+++ b/src/View/GetHelp.elm
@@ -26,7 +26,7 @@ view viewportWidth =
             , nav [ css [ navListStyle ] ]
                 [ p [ css [ reassuringStyle ] ]
                     [ text (t ToHelpSelfReassuringText) ]
-                , renderNavLink Forward HelpSelfGrid ToHelpSelfFromGetHelpLink
+                , renderNavLink None HelpSelfGrid ToHelpSelfFromGetHelpLink
                 ]
             ]
         , verticalSpacing 2


### PR DESCRIPTION
Trello card: 
https://trello.com/c/denN8le5/471-copy-changes-before-release

## Description

- Better exit, emergency and landing page styles

![Screenshot_20200921_152425](https://user-images.githubusercontent.com/861172/93779038-6d3aa600-fc1e-11ea-95cf-7f52c0d5ac82.png)


@neontribe/sea-map
