### PR TITLE
Temporary bugfix - always init gtag with config

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,8 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
+
+      gtag('config', 'UA-30970110-8');
     </script>
   </head>
 

--- a/src/index.html
+++ b/src/index.html
@@ -20,8 +20,6 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
-      gtag('config', 'UA-30970110-8');
     </script>
   </head>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -19,9 +19,13 @@ elm.ports.saveConsent.subscribe(function (hasConsented) {
 
 // Google analytics subscribe to page changes and custom events
 elm.ports.updateAnalyticsPage.subscribe(function (page) {
-  gtag("config", "UA-30970110-8", { "page_path" : page });
+    if (typeof window !="undefined") {
+      gtag("config", "UA-30970110-8", { "page_path" : page });
+    }
 });
 
 elm.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
-  gtag("event", gaEvent.action, { "event_category" : gaEvent.category, "event_label" : gaEvent.label });
+  if (typeof window != "undefined") {
+    gtag("event", gaEvent.action, { "event_category" : gaEvent.category, "event_label" : gaEvent.label });
+  }
 });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -19,6 +19,10 @@ elm.ports.saveConsent.subscribe(function (hasConsented) {
 // Google analytics subscribe to page changes and custom events
 elm.ports.updateAnalyticsPage.subscribe(function (page) {
     if (typeof window != undefined) {
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
       gtag("config", "UA-30970110-8", { "page_path" : page });
     }
 });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -18,13 +18,17 @@ elm.ports.saveConsent.subscribe(function (hasConsented) {
 
 // Google analytics subscribe to page changes and custom events
 elm.ports.updateAnalyticsPage.subscribe(function (page) {
-    if (typeof window != undefined && gtag) {
+    if (typeof window != undefined) {
       gtag("config", "UA-30970110-8", { "page_path" : page });
     }
 });
 
 elm.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
-  if (typeof window != undefined && gtag) {
+  if (typeof window != undefined) {
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
     gtag("event", gaEvent.action, { "event_category" : gaEvent.category, "event_label" : gaEvent.label });
   }
 });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,6 +1,5 @@
 import { Elm } from "../Main.elm";
 
-
 var hasConsented = sessionStorage.getItem("ga-cookie-consent") ? sessionStorage.getItem("ga-cookie-consent") : "null";
 
 var elm = Elm.Main.init({
@@ -19,13 +18,13 @@ elm.ports.saveConsent.subscribe(function (hasConsented) {
 
 // Google analytics subscribe to page changes and custom events
 elm.ports.updateAnalyticsPage.subscribe(function (page) {
-    if (typeof window !="undefined") {
+    if (typeof window != undefined && gtag) {
       gtag("config", "UA-30970110-8", { "page_path" : page });
     }
 });
 
 elm.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
-  if (typeof window != "undefined") {
+  if (typeof window != undefined && gtag) {
     gtag("event", gaEvent.action, { "event_category" : gaEvent.category, "event_label" : gaEvent.label });
   }
 });


### PR DESCRIPTION
Trello card: https://trello.com/c/K6GY0FNG/229-vvv-eee-add-google-analytics-with-cookie-banner-functional-with-page-tracking-some-events

Not even sure if this will fix the issue. Seems to be a problem in production, not development.

## Description

- Revert to always loading the config, but only send data if accept after that initial load
- More permanent bugfix: https://trello.com/c/yQyStmiy/474-when-i-accept-there-is-a-gtag-not-defined-error-that-stops-page-from-loading-until-i-refresh-the-page

@neontribe/sea-map