### PR TITLE
prevent not alone cards from squashing too much

### DIFF
--- a/src/View/NotAlone.elm
+++ b/src/View/NotAlone.elm
@@ -125,7 +125,7 @@ cardStyle =
         , width oneColumn
         , withMediaDesktop
             [ flex3 zero zero threeColumn
-            , width threeColumn
+            , width (px 368)
             , nthOfType "3n-1"
                 [ marginTop (rem 6)
                 ]


### PR DESCRIPTION
Trello card: https://trello.com/c/bRMQhCce/425-ee-breakpoints

## Description

- Small change after IE fixes. Stopping the width being a percent value should allow the cards to flex-wrap

Before -> After

![image](https://user-images.githubusercontent.com/32434620/95481149-98462900-0984-11eb-9163-bd88faf151d9.png)


@neontribe/sea-map
