### PR TITLE
Fire analytics page view on external link

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -108,16 +108,8 @@ update msg model =
 
                 Browser.External href ->
                     let
-                        page =
-                            Page.toString model.page
-
                         analyticsEvent =
-                            { category =
-                                if page == "" then
-                                    "homepage"
-
-                                else
-                                    page
+                            { category = Page.toString model.page
                             , action = "clicked external link"
                             , label = href
                             }
@@ -153,7 +145,23 @@ update msg model =
             ( { model | viewportWidth = Maybe.withDefault model.viewportWidth (Just viewport.scene.width) }, Cmd.none )
 
         EmergencyButtonClicked ->
-            ( { model | emergencyPopupIsOpen = not model.emergencyPopupIsOpen }, Cmd.none )
+            let
+                action =
+                    if model.emergencyPopupIsOpen then
+                        "closed"
+
+                    else
+                        "opened"
+            in
+            ( { model | emergencyPopupIsOpen = not model.emergencyPopupIsOpen }
+            , updateAnalytics model.cookieState.hasConsentedToCookies
+                (updateAnalyticsEvent
+                    { category = Page.toString model.page
+                    , action = action
+                    , label = t EmergencyButton
+                    }
+                )
+            )
 
         CookieButtonClicked button ->
             let

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -108,7 +108,10 @@ update msg model =
 
                 Browser.External href ->
                     ( model
-                    , Browser.Navigation.load href
+                    , Cmd.batch
+                        [ Browser.Navigation.load href
+                        , updateAnalytics model.cookieState.hasConsentedToCookies (updateAnalyticsPage href)
+                        ]
                     )
 
         UrlChanged url ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (main)
 
-import Analytics exposing (updateAnalytics, updateAnalyticsPage)
+import Analytics exposing (updateAnalytics, updateAnalyticsEvent, updateAnalyticsPage)
 import Browser
 import Browser.Dom
 import Browser.Navigation
@@ -107,10 +107,25 @@ update msg model =
                     )
 
                 Browser.External href ->
+                    let
+                        page =
+                            Page.toString model.page
+
+                        analyticsEvent =
+                            { category =
+                                if page == "" then
+                                    "homepage"
+
+                                else
+                                    page
+                            , action = "clicked external link"
+                            , label = href
+                            }
+                    in
                     ( model
                     , Cmd.batch
                         [ Browser.Navigation.load href
-                        , updateAnalytics model.cookieState.hasConsentedToCookies (updateAnalyticsPage href)
+                        , updateAnalytics model.cookieState.hasConsentedToCookies (updateAnalyticsEvent analyticsEvent)
                         ]
                     )
 

--- a/src/Page/NotAlone.elm
+++ b/src/Page/NotAlone.elm
@@ -46,7 +46,7 @@ update msg model =
             ( { model | revealedJourney = revealedCardData.position }
             , updateAnalytics hasConsented
                 (updateAnalyticsEvent
-                    { category = "homepage"
+                    { category = "/"
                     , action = revealedCardData.action
                     , label = labelFromCardPosition journeyCardPosition
                     }

--- a/src/Page/NotAlone.elm
+++ b/src/Page/NotAlone.elm
@@ -46,7 +46,7 @@ update msg model =
             ( { model | revealedJourney = revealedCardData.position }
             , updateAnalytics hasConsented
                 (updateAnalyticsEvent
-                    { category = t NotAlonePageSlug
+                    { category = "homepage"
                     , action = revealedCardData.action
                     , label = labelFromCardPosition journeyCardPosition
                     }


### PR DESCRIPTION
Trello card: 
https://trello.com/c/Fi5XQXRb/460-add-google-analytics-event-to-emergency-exit-site-external-links-eg-forum-pdfs-email-phone-etc

## Description

- Testing external link page view (probably want an event instead)
- Still todo add emergency and exit button events

@neontribe/sea-map
