### PR TITLE
Correct GA Number

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -23,7 +23,7 @@ elm.ports.updateAnalyticsPage.subscribe(function (page) {
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag("config", "UA-30970110-8", { "page_path" : page });
+      gtag("config", "UA-124167481-1", { "page_path" : page });
     }
 });
 


### PR DESCRIPTION
Trello card: https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Ftrello.com%2Fc%2F13gNh7Bg%2F432-e-sweep-for-ccc-deap-google-analytics-ua-before-live

## Description

- Updated GA Number 
-

@neontribe/sea-map
