### PR TITLE
Feat/487 add footer copyright

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,11 +11,11 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {
-            "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0"
         }

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -62,6 +62,8 @@ type Key
     | HelpSelfSeparatingResource1Href
     | HelpSelfSeparatingResource2Href
     | HelpSelfSeparatingResource3Href
+      -- Footer
+    | CopyrightText String
       -- Cookies and Privacy
     | CookieBannerP
     | CookieBannerPrivacyButton

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -74,7 +74,6 @@ t key =
         HelpSelfFinancialDescription ->
             "Learn about what financial support is available if you are experiencing economic abuse. We have information on grants, immigration and child support."
 
-
         HelpSelfInfoLawMetaTitle ->
             t HelpSelfInfoLawTitle
 
@@ -114,7 +113,6 @@ t key =
 
         HelpSelfFinancialSlug ->
             "financial-support"
-
 
         HelpSelfInfoLawSlug ->
             "the-law"
@@ -173,7 +171,6 @@ t key =
         HelpSelfFinancialResource3Href ->
             "https://survivingeconomicabuse.org/i-need-help/getting-support/no-recourse-to-public-funds/"
 
-
         HelpSelfInfoLawResource1Href ->
             "https://survivingeconomicabuse.org/i-need-help/economic-abuse-and-the-law/controlling-or-coercive-behaviour/"
 
@@ -191,6 +188,10 @@ t key =
 
         HelpSelfSeparatingResource3Href ->
             "https://survivingeconomicabuse.org/i-need-help/de-linking-from-the-abuser/preparing-to-leave-an-abuser/"
+
+        -- Footer
+        CopyrightText yearNow ->
+            "© 2020 - " ++ yearNow ++ " Surviving Economic Abuse"
 
         -- Cookies and Privacy
         CookieBannerP ->
@@ -487,7 +488,6 @@ t key =
 
         HelpSelfFinancialLink ->
             "Financial support"
-
 
         HelpSelfInfoLawLink ->
             "The law"

--- a/src/FooterContent.elm
+++ b/src/FooterContent.elm
@@ -6,7 +6,7 @@ import Css exposing (..)
 import Html.Styled exposing (Html, div, text)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg(..))
-import Theme exposing (shadowGrey)
+import Theme exposing (shadowGrey, withMediaMobile)
 
 
 renderCopyright : String -> Html Msg
@@ -20,4 +20,9 @@ copyrightStyle =
         [ color shadowGrey
         , marginTop (px -25)
         , textAlign center
+        , withMediaMobile
+            [ fontSize (rem 0.8)
+            , paddingRight (px 4)
+            , textAlign right
+            ]
         ]

--- a/src/FooterContent.elm
+++ b/src/FooterContent.elm
@@ -1,0 +1,23 @@
+module FooterContent exposing (renderCopyright)
+
+import Copy.Keys exposing (Key(..))
+import Copy.Text exposing (t)
+import Css exposing (..)
+import Html.Styled exposing (Html, div, text)
+import Html.Styled.Attributes exposing (css)
+import Message exposing (Msg(..))
+import Theme exposing (shadowGrey)
+
+
+renderCopyright : String -> Html Msg
+renderCopyright yearNow =
+    div [ css [ copyrightStyle ] ] [ text (t (CopyrightText yearNow)) ]
+
+
+copyrightStyle : Style
+copyrightStyle =
+    batch
+        [ color shadowGrey
+        , marginTop (px -25)
+        , textAlign center
+        ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -9,6 +9,7 @@ import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Css exposing (..)
 import EmergencyContent exposing (renderEmergencyButton, renderEmergencyPanel, renderExitButton)
+import FooterContent exposing (renderCopyright)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (..)
 import Message exposing (CookieButton(..), Msg(..))
@@ -20,6 +21,7 @@ import Page.NotAlone
 import Route exposing (Route(..))
 import Task
 import Theme exposing (..)
+import Time
 import Url
 import View.Definition
 import View.GetHelp
@@ -48,6 +50,7 @@ type alias Model =
     { key : Browser.Navigation.Key
     , page : Page
     , viewportWidth : Float
+    , timeNow : Time.Posix
     , emergencyPopupIsOpen : Bool
     , cookieState : CookieState
     }
@@ -79,6 +82,7 @@ init hasConsentedString url key =
     ( { key = key
       , page = page
       , viewportWidth = 800
+      , timeNow = Time.millisToPosix 0
       , emergencyPopupIsOpen = False
       , cookieState =
             { cookieBannerIsOpen = viewCookieBannerContent
@@ -88,6 +92,7 @@ init hasConsentedString url key =
       }
     , Cmd.batch
         [ Task.perform GotViewport Browser.Dom.getViewport
+        , Task.perform GetTime Time.now
         , setMetaDescription (metaFromPage page).description
         ]
     )
@@ -140,6 +145,9 @@ update msg model =
                 , updateAnalytics hasConsented (updateAnalyticsPage (Route.toString route))
                 ]
             )
+
+        GetTime timeNow ->
+            ( { model | timeNow = timeNow }, Cmd.none )
 
         GotViewport viewport ->
             ( { model | viewportWidth = Maybe.withDefault model.viewportWidth (Just viewport.scene.width) }, Cmd.none )
@@ -290,6 +298,7 @@ view model =
           else
             renderEmergencyButton
         , renderCookieContent model.cookieState
+        , renderCopyright (Time.toYear Time.utc model.timeNow |> String.fromInt)
         ]
 
 

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -5,6 +5,7 @@ import Browser.Dom
 import Page.Definition
 import Page.HelpSelfSingle
 import Page.NotAlone
+import Time
 import Url
 
 
@@ -16,6 +17,7 @@ type Msg
     = NoOp
     | PageLinkClicked Browser.UrlRequest
     | UrlChanged Url.Url
+    | GetTime Time.Posix
     | GotViewport Browser.Dom.Viewport
     | EmergencyButtonClicked
     | CookieButtonClicked CookieButton

--- a/src/Theme.elm
+++ b/src/Theme.elm
@@ -1,4 +1,4 @@
-module Theme exposing (container, containerContent, darkOrange, expanderButtonStyle, expanderClosedStyle, expanderDefinitionStyles, expanderHeadingStyle, expanderItemStyle, expanderOpenStyle, expanderSymbolStyle, generateId, globalStyles, green, grey, gridStyle, lightGreen, lightGrey, lightOrange, lightPink, lightPurple, lightTeal, maxMobile, navItemStyles, navListStyle, oneColumn, orange, pageHeadingStyle, pink, pureWhite, purple, quoteStyle, renderWithKeywords, rotate90Style, shadowGrey, teal, threeColumn, twoColumn, verticalSpacing, waveStyle, white, withMediaDesktop, withMediaTablet)
+module Theme exposing (container, containerContent, darkOrange, expanderButtonStyle, expanderClosedStyle, expanderDefinitionStyles, expanderHeadingStyle, expanderItemStyle, expanderOpenStyle, expanderSymbolStyle, generateId, globalStyles, green, grey, gridStyle, lightGreen, lightGrey, lightOrange, lightPink, lightPurple, lightTeal, maxMobile, navItemStyles, navListStyle, oneColumn, orange, pageHeadingStyle, pink, pureWhite, purple, quoteStyle, renderWithKeywords, rotate90Style, shadowGrey, teal, threeColumn, twoColumn, verticalSpacing, waveStyle, white, withMediaDesktop, withMediaMobile, withMediaTablet)
 
 import Css exposing (..)
 import Css.Global exposing (adjacentSiblings, global, typeSelector)
@@ -119,6 +119,11 @@ pureWhite =
 maxMobile : Float
 maxMobile =
     576
+
+
+withMediaMobile : List Style -> Style
+withMediaMobile =
+    withMedia [ only screen [ Media.maxWidth (px maxMobile) ] ]
 
 
 withMediaTablet : List Style -> Style


### PR DESCRIPTION
Trello card: 
https://trello.com/c/qMIvc7Go/487-footer-copyright-information

## Description

- Add copyright into to footer
- Very light grey
- Fully visible on mobile screens > 400px
- dynamic end year

@neontribe/sea-map
